### PR TITLE
ci: Add InfraScan audit workflow for IaC security and cost optimization

### DIFF
--- a/.github/workflows/infrascan.yml‎
+++ b/.github/workflows/infrascan.yml‎
@@ -1,0 +1,32 @@
+name: InfraScan Audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  infrascan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create Reports Directory
+        run: |
+          mkdir -p infrascan-reports
+          chmod 777 infrascan-reports
+
+      - name: Run InfraScan
+        uses: soldevelo/infrascan@v1.0.5
+        with:
+          scanner: comprehensive
+          format: html
+          out: infrascan-reports/report.html
+            
+      - name: Upload InfraScan Report
+        uses: actions/upload-artifact@v4
+        if: always() # Upload report even if the scan step fails
+        with:
+          name: infrascan-report
+          path: infrascan-reports/report.html
+          retention-days: 14

--- a/.github/workflows/infrascan.yml‎
+++ b/.github/workflows/infrascan.yml‎
@@ -17,7 +17,7 @@ jobs:
           chmod 777 infrascan-reports
 
       - name: Run InfraScan
-        uses: soldevelo/infrascan@v1.0.5
+        uses: soldevelo/infrascan@v1.0.6
         with:
           scanner: comprehensive
           format: html


### PR DESCRIPTION
To improve infrastructure's quality, security, and cost-efficiency, I am adding a new CI/CD workflow powered by **InfraScan**.

### What does this PR change?
* **Automated IaC Scanning:** Every `push` and `pull_request` will now be automatically audited for Terraform, Kubernetes, and Dockerfile misconfigurations.
* **Comprehensive Analysis:** We are using the `comprehensive` scanner mode, which covers:
    * **Security:** Detection of vulnerabilities and permission issues (via Checkov).
    * **Cost Optimization:** Identification of "low-hanging fruit" like old-gen instances or missing S3 lifecycle policies.
    * **Container Auditing:** Scanning image references for known CVEs.

### Free Reports & Artifacts
The workflow is configured to provide immediate feedback through visual reporting:
1. **Interactive HTML Format:** Generates a standalone dashboard with A-F grading.
2. **Action Artifacts:** The report is automatically uploaded as a GitHub Action artifact named `infrascan-report`.
3. **Persistence:** Reports are stored for **14 days** and can be downloaded by anyone on the team.

### How to access the results?
1. Go to the **Actions** tab of this repository.
2. Select the latest **InfraScan Audit** run.
3. Scroll down to the **Artifacts** section and download `infrascan-report`.
4. Open the `report.html` file in your browser to view the smart recommendations and risk assessments.